### PR TITLE
Add workflow-selectable ACP and Claude backends

### DIFF
--- a/elixir/README.md
+++ b/elixir/README.md
@@ -99,6 +99,8 @@ hooks:
 agent:
   max_concurrent_agents: 10
   max_turns: 20
+agent_backend:
+  id: codex_app_server
 codex:
   command: codex app-server
 ---
@@ -111,6 +113,10 @@ Title: {{ issue.title }} Body: {{ issue.description }}
 Notes:
 
 - If a value is missing, defaults are used.
+- `agent_backend.id` selects the execution backend. Supported values:
+  - `codex_app_server` (default compatibility path; still uses the `codex` block)
+  - `acp_stdio` (defaults to `opencode acp` unless `agent_backend.command` is set)
+  - `claude_cli_stream` (defaults to `claude` unless `agent_backend.command` is set)
 - Safer Codex defaults are used when policy fields are omitted:
   - `codex.approval_policy` defaults to `{"reject":{"sandbox_approval":true,"rules":true,"mcp_elicitations":true}}`
   - `codex.thread_sandbox` defaults to `workspace-write`
@@ -120,7 +126,7 @@ Notes:
 - When `codex.turn_sandbox_policy` is set explicitly, Symphony passes the map through to Codex
   unchanged. Compatibility then depends on the targeted Codex app-server version rather than local
   Symphony validation.
-- `agent.max_turns` caps how many back-to-back Codex turns Symphony will run in a single agent
+- `agent.max_turns` caps how many back-to-back agent turns Symphony will run in a single worker
   invocation when a turn completes normally but the issue is still in an active state. Default: `20`.
 - If the Markdown body is blank, Symphony uses a default prompt template that includes the issue
   identifier, title, and body.
@@ -139,6 +145,9 @@ tracker:
   api_key: $LINEAR_API_KEY
 workspace:
   root: $SYMPHONY_WORKSPACE_ROOT
+agent_backend:
+  id: acp_stdio
+  command: "$OPENCODE_BIN acp"
 hooks:
   after_create: |
     git clone --depth 1 "$SOURCE_REPO_URL" .

--- a/elixir/lib/symphony_elixir/agent_backend/acp_stdio.ex
+++ b/elixir/lib/symphony_elixir/agent_backend/acp_stdio.ex
@@ -1,0 +1,370 @@
+defmodule SymphonyElixir.AgentBackend.AcpStdio do
+  @moduledoc """
+  ACP-over-stdio backend for agents such as `opencode acp`.
+  """
+
+  @behaviour SymphonyElixir.AgentBackend
+
+  require Logger
+
+  alias SymphonyElixir.AgentBackend
+  alias SymphonyElixir.AgentBackend.CommandPort
+  alias SymphonyElixir.Config
+
+  @backend_name :acp_stdio
+  @initialize_id 1
+  @session_new_id 2
+  @session_close_id 3
+
+  @impl true
+  def start_session(context, _opts) do
+    backend_settings = Config.agent_backend_settings()
+    workspace = AgentBackend.value_from(context, :workspace_path)
+    worker_host = AgentBackend.value_from(context, :worker_host)
+    on_event = AgentBackend.value_from(context, :on_event) || fn _event -> :ok end
+
+    with {:ok, command_session} <- CommandPort.start(workspace, worker_host, backend_settings.command) do
+      with :ok <- send_initialize(command_session.port),
+           {:ok, initialize_result} <- await_response(command_session.port, @initialize_id, backend_settings.read_timeout_ms),
+           {:ok, session_id} <- create_session(command_session.port, command_session.workspace, backend_settings.read_timeout_ms) do
+        {:ok,
+         %{
+           metadata: command_session.metadata,
+           on_event: on_event,
+           port: command_session.port,
+           read_timeout_ms: backend_settings.read_timeout_ms,
+           session_capabilities: session_capabilities(initialize_result),
+           session_id: session_id,
+           turn_timeout_ms: backend_settings.turn_timeout_ms,
+           worker_host: command_session.worker_host,
+           workspace: command_session.workspace
+         }}
+      else
+        {:error, reason} = error ->
+          Logger.warning("ACP backend failed to start session: #{inspect(reason)}")
+          CommandPort.stop(command_session)
+          error
+      end
+    end
+  end
+
+  @impl true
+  def run_turn(session, turn, _opts) do
+    prompt_id = 1_000 + turn.turn_number
+    turn_id = Integer.to_string(turn.turn_number)
+    session_id = composite_session_id(session.session_id, turn_id)
+
+    emit_event(
+      session,
+      %{
+        event: :session_started,
+        session_id: session_id,
+        thread_id: session.session_id,
+        turn_id: turn_id,
+        payload: %{"method" => "session/prompt"}
+      }
+    )
+
+    CommandPort.send_json(session.port, %{
+      "jsonrpc" => "2.0",
+      "id" => prompt_id,
+      "method" => "session/prompt",
+      "params" => %{
+        "sessionId" => session.session_id,
+        "prompt" => [
+          %{
+            "type" => "text",
+            "text" => turn.prompt
+          }
+        ]
+      }
+    })
+
+    await_prompt_completion(session, prompt_id, session_id, turn_id)
+  end
+
+  @impl true
+  def stop_session(%{port: port, read_timeout_ms: read_timeout_ms, session_capabilities: capabilities, session_id: session_id} = session)
+      when is_port(port) do
+    if close_supported?(capabilities) do
+      CommandPort.send_json(port, %{
+        "jsonrpc" => "2.0",
+        "id" => @session_close_id,
+        "method" => "session/close",
+        "params" => %{
+          "sessionId" => session_id
+        }
+      })
+
+      _ = await_response(port, @session_close_id, read_timeout_ms)
+    end
+
+    CommandPort.stop(session)
+  end
+
+  def stop_session(session), do: CommandPort.stop(session)
+
+  defp send_initialize(port) when is_port(port) do
+    CommandPort.send_json(port, %{
+      "jsonrpc" => "2.0",
+      "id" => @initialize_id,
+      "method" => "initialize",
+      "params" => %{
+        "protocolVersion" => 1,
+        "clientCapabilities" => %{},
+        "clientInfo" => %{
+          "name" => "symphony",
+          "title" => "Symphony",
+          "version" => "0.1.0"
+        }
+      }
+    })
+  end
+
+  defp create_session(port, workspace, timeout_ms) when is_port(port) and is_binary(workspace) do
+    CommandPort.send_json(port, %{
+      "jsonrpc" => "2.0",
+      "id" => @session_new_id,
+      "method" => "session/new",
+      "params" => %{
+        "cwd" => workspace,
+        "mcpServers" => []
+      }
+    })
+
+    case await_response(port, @session_new_id, timeout_ms) do
+      {:ok, %{"sessionId" => session_id}} when is_binary(session_id) ->
+        {:ok, session_id}
+
+      {:ok, payload} ->
+        {:error, {:invalid_session_response, payload}}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp await_response(port, request_id, timeout_ms) when is_port(port) do
+    case CommandPort.receive_json(port, timeout_ms) do
+      {:ok, %{"id" => ^request_id, "result" => result}, _pending_line} ->
+        {:ok, result}
+
+      {:ok, %{"id" => ^request_id, "error" => error}, _pending_line} ->
+        {:error, {:json_rpc_error, error}}
+
+      {:ok, _payload, _pending_line} ->
+        await_response(port, request_id, timeout_ms)
+
+      {:malformed, raw, _pending_line} ->
+        Logger.debug("ACP startup emitted non-JSON output: #{inspect(raw)}")
+        await_response(port, request_id, timeout_ms)
+
+      {:error, :timeout} ->
+        {:error, :read_timeout}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp await_prompt_completion(session, prompt_id, session_id, turn_id) do
+    case CommandPort.receive_json(session.port, session.turn_timeout_ms) do
+      {:ok, %{"id" => ^prompt_id, "result" => result} = payload, _pending_line} ->
+        emit_event(
+          session,
+          %{
+            event: :turn_completed,
+            session_id: session_id,
+            thread_id: session.session_id,
+            turn_id: turn_id,
+            payload: payload
+          }
+        )
+
+        {:ok,
+         %{
+           backend: @backend_name,
+           result: result,
+           session_id: session_id,
+           thread_id: session.session_id,
+           turn_id: turn_id
+         }}
+
+      {:ok, %{"id" => ^prompt_id, "error" => error} = payload, _pending_line} ->
+        emit_event(
+          session,
+          %{
+            event: :turn_failed,
+            session_id: session_id,
+            thread_id: session.session_id,
+            turn_id: turn_id,
+            payload: payload
+          }
+        )
+
+        {:error, {:json_rpc_error, error}}
+
+      {:ok, %{"method" => "session/update"} = payload, _pending_line} ->
+        emit_event(
+          session,
+          %{
+            event: :notification,
+            session_id: session_id,
+            thread_id: session.session_id,
+            turn_id: turn_id,
+            payload: payload
+          }
+        )
+
+        await_prompt_completion(session, prompt_id, session_id, turn_id)
+
+      {:ok, %{"id" => request_id, "method" => "session/request_permission", "params" => params} = payload, _pending_line}
+      when is_integer(request_id) or is_binary(request_id) ->
+        respond_to_permission_request(session.port, request_id, params)
+
+        emit_event(
+          session,
+          %{
+            event: :notification,
+            session_id: session_id,
+            thread_id: session.session_id,
+            turn_id: turn_id,
+            payload: payload
+          }
+        )
+
+        await_prompt_completion(session, prompt_id, session_id, turn_id)
+
+      {:ok, %{"id" => request_id, "method" => method} = payload, _pending_line}
+      when (is_integer(request_id) or is_binary(request_id)) and is_binary(method) ->
+        respond_method_not_found(session.port, request_id, method)
+
+        emit_event(
+          session,
+          %{
+            event: :notification,
+            session_id: session_id,
+            thread_id: session.session_id,
+            turn_id: turn_id,
+            payload: payload
+          }
+        )
+
+        await_prompt_completion(session, prompt_id, session_id, turn_id)
+
+      {:ok, payload, _pending_line} ->
+        emit_event(
+          session,
+          %{
+            event: :notification,
+            session_id: session_id,
+            thread_id: session.session_id,
+            turn_id: turn_id,
+            payload: payload
+          }
+        )
+
+        await_prompt_completion(session, prompt_id, session_id, turn_id)
+
+      {:malformed, raw, _pending_line} ->
+        emit_event(
+          session,
+          %{
+            event: :malformed,
+            session_id: session_id,
+            thread_id: session.session_id,
+            turn_id: turn_id,
+            payload: raw,
+            raw: raw
+          }
+        )
+
+        await_prompt_completion(session, prompt_id, session_id, turn_id)
+
+      {:error, :timeout} ->
+        {:error, :turn_timeout}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp respond_to_permission_request(port, request_id, params) do
+    option_id = permission_option_id(params)
+
+    CommandPort.send_json(port, %{
+      "jsonrpc" => "2.0",
+      "id" => request_id,
+      "result" => %{
+        "outcome" => %{
+          "outcome" => "selected",
+          "optionId" => option_id
+        }
+      }
+    })
+  end
+
+  defp respond_method_not_found(port, request_id, method) do
+    CommandPort.send_json(port, %{
+      "jsonrpc" => "2.0",
+      "id" => request_id,
+      "error" => %{
+        "code" => -32601,
+        "message" => "Unsupported ACP client method #{method}"
+      }
+    })
+  end
+
+  defp permission_option_id(%{"options" => options}) when is_list(options) do
+    options
+    |> Enum.find(fn option ->
+      kind = option["kind"] || option[:kind]
+      kind in ["allow_once", "allow_always", :allow_once, :allow_always]
+    end)
+    |> case do
+      nil ->
+        options
+        |> List.first()
+        |> option_id()
+
+      option ->
+        option_id(option)
+    end
+  end
+
+  defp permission_option_id(_params), do: nil
+
+  defp option_id(option) when is_map(option) do
+    option["optionId"] || option[:optionId] || option["option_id"] || option[:option_id]
+  end
+
+  defp option_id(_option), do: nil
+
+  defp session_capabilities(result) when is_map(result) do
+    get_in(result, ["agentCapabilities", "sessionCapabilities"]) ||
+      get_in(result, [:agentCapabilities, :sessionCapabilities]) ||
+      %{}
+  end
+
+  defp session_capabilities(_result), do: %{}
+
+  defp close_supported?(capabilities) when is_map(capabilities) do
+    close_capability = capabilities["close"] || capabilities[:close]
+    is_map(close_capability)
+  end
+
+  defp close_supported?(_capabilities), do: false
+
+  defp composite_session_id(raw_session_id, turn_id) when is_binary(raw_session_id) and is_binary(turn_id) do
+    "#{raw_session_id}-turn-#{turn_id}"
+  end
+
+  defp emit_event(session, payload) when is_map(payload) do
+    session.on_event.(
+      AgentBackend.normalize_runtime_event(
+        @backend_name,
+        Map.merge(session.metadata, Map.put_new(payload, :timestamp, DateTime.utc_now()))
+      )
+    )
+  end
+end

--- a/elixir/lib/symphony_elixir/agent_backend/claude_cli_stream.ex
+++ b/elixir/lib/symphony_elixir/agent_backend/claude_cli_stream.ex
@@ -1,0 +1,241 @@
+defmodule SymphonyElixir.AgentBackend.ClaudeCliStream do
+  @moduledoc """
+  Claude Code backend that runs `claude -p` in stream-json mode and resumes
+  the same Claude session across logical Symphony turns.
+  """
+
+  @behaviour SymphonyElixir.AgentBackend
+
+  alias SymphonyElixir.AgentBackend
+  alias SymphonyElixir.AgentBackend.CommandPort
+  alias SymphonyElixir.Config
+
+  @backend_name :claude_cli_stream
+
+  @impl true
+  def start_session(context, _opts) do
+    backend_settings = Config.agent_backend_settings()
+
+    initial_state = %{
+      command: backend_settings.command,
+      on_event: AgentBackend.value_from(context, :on_event) || fn _event -> :ok end,
+      raw_session_id: nil,
+      read_timeout_ms: backend_settings.read_timeout_ms,
+      turn_timeout_ms: backend_settings.turn_timeout_ms,
+      worker_host: AgentBackend.value_from(context, :worker_host),
+      workspace: AgentBackend.value_from(context, :workspace_path)
+    }
+
+    Agent.start_link(fn -> initial_state end)
+  end
+
+  @impl true
+  def run_turn(session_pid, turn, _opts) when is_pid(session_pid) do
+    state = Agent.get(session_pid, & &1)
+    command = claude_command(state.command, turn.prompt, state.raw_session_id)
+
+    with {:ok, port_session} <- CommandPort.start(state.workspace, state.worker_host, command),
+         result <- consume_stream(state, port_session, turn) do
+      CommandPort.stop(port_session)
+      finalize_turn(session_pid, result, turn)
+    end
+  end
+
+  @impl true
+  def stop_session(session_pid) when is_pid(session_pid) do
+    Agent.stop(session_pid, :normal, 5_000)
+  catch
+    :exit, _reason -> :ok
+  end
+
+  def stop_session(_session), do: :ok
+
+  defp consume_stream(state, port_session, turn) do
+    turn_id = Integer.to_string(turn.turn_number)
+
+    stream_loop(
+      state,
+      port_session,
+      turn_id,
+      %{
+        composite_session_id: nil,
+        emitted_session_started?: false,
+        raw_session_id: state.raw_session_id,
+        result_message: nil
+      }
+    )
+  end
+
+  defp stream_loop(state, port_session, turn_id, acc) do
+    case CommandPort.receive_json(port_session.port, state.turn_timeout_ms) do
+      {:ok, message, _pending_line} ->
+        next_acc = handle_stream_message(state, port_session, turn_id, acc, message)
+        stream_loop(state, port_session, turn_id, next_acc)
+
+      {:malformed, raw, _pending_line} ->
+        next_acc =
+          if acc.result_message do
+            acc
+          else
+            emit_event(state, port_session.metadata, acc, turn_id, %{
+              event: :malformed,
+              payload: raw,
+              raw: raw
+            })
+          end
+
+        stream_loop(state, port_session, turn_id, next_acc)
+
+      {:error, {:port_exit, status}} ->
+        {:port_exit, status, acc}
+
+      {:error, :timeout} ->
+        {:error, :turn_timeout, acc}
+
+      {:error, reason} ->
+        {:error, reason, acc}
+    end
+  end
+
+  defp handle_stream_message(state, port_session, turn_id, acc, message) do
+    raw_session_id = extract_session_id(message) || acc.raw_session_id
+    composite_session_id = acc.composite_session_id || composite_session_id(raw_session_id, turn_id)
+
+    acc =
+      %{
+        acc
+        | raw_session_id: raw_session_id,
+          composite_session_id: composite_session_id
+      }
+
+    acc =
+      if raw_session_id && not acc.emitted_session_started? do
+        emit_event(state, port_session.metadata, acc, turn_id, %{
+          event: :session_started,
+          payload: message
+        })
+      else
+        acc
+      end
+
+    if acc.result_message do
+      acc
+    else
+      case message_type(message) do
+        "result" ->
+          subtype = Map.get(message, "subtype")
+          event = if subtype == "success", do: :turn_completed, else: :turn_failed
+
+          emit_event(state, port_session.metadata, acc, turn_id, %{
+            event: event,
+            payload: message,
+            usage: extract_usage(message)
+          })
+          |> Map.put(:result_message, message)
+
+        _ ->
+          emit_event(state, port_session.metadata, acc, turn_id, %{
+            event: :notification,
+            payload: message,
+            usage: extract_usage(message)
+          })
+      end
+    end
+  end
+
+  defp finalize_turn(session_pid, {:port_exit, status, %{result_message: result_message} = acc}, turn)
+       when status in [0, nil] and is_map(result_message) do
+    Agent.update(session_pid, fn state -> %{state | raw_session_id: acc.raw_session_id} end)
+
+    case Map.get(result_message, "subtype") do
+      "success" ->
+        {:ok,
+         %{
+           backend: @backend_name,
+           result: Map.get(result_message, "result"),
+           session_id: acc.composite_session_id,
+           thread_id: acc.raw_session_id,
+           turn_id: Integer.to_string(turn.turn_number)
+         }}
+
+      subtype ->
+        {:error, {:claude_result, subtype, result_message}}
+    end
+  end
+
+  defp finalize_turn(_session_pid, {:port_exit, status, %{result_message: nil}}, _turn) do
+    {:error, {:port_exit, status}}
+  end
+
+  defp finalize_turn(_session_pid, {:error, reason, _acc}, _turn), do: {:error, reason}
+
+  defp emit_event(state, metadata, acc, turn_id, payload) when is_map(payload) do
+    if acc.raw_session_id do
+      state.on_event.(
+        AgentBackend.normalize_runtime_event(
+          @backend_name,
+          Map.merge(metadata, %{
+            event: payload.event,
+            timestamp: DateTime.utc_now(),
+            session_id: acc.composite_session_id,
+            thread_id: acc.raw_session_id,
+            turn_id: turn_id,
+            payload: payload[:payload],
+            raw: payload[:raw],
+            usage: payload[:usage]
+          })
+        )
+      )
+
+      %{acc | emitted_session_started?: true}
+    else
+      acc
+    end
+  end
+
+  defp claude_command(base_command, prompt, raw_session_id)
+       when is_binary(base_command) and is_binary(prompt) do
+    resume_arg =
+      case raw_session_id do
+        session_id when is_binary(session_id) and session_id != "" ->
+          " --resume " <> CommandPort.shell_escape(session_id)
+
+        _ ->
+          ""
+      end
+
+    base_command <>
+      " --print --output-format stream-json --verbose --include-partial-messages" <>
+      resume_arg <>
+      " " <> CommandPort.shell_escape(prompt)
+  end
+
+  defp composite_session_id(raw_session_id, turn_id)
+       when is_binary(raw_session_id) and is_binary(turn_id) do
+    "#{raw_session_id}-turn-#{turn_id}"
+  end
+
+  defp composite_session_id(_raw_session_id, _turn_id), do: nil
+
+  defp message_type(message) when is_map(message) do
+    Map.get(message, "type") || Map.get(message, :type)
+  end
+
+  defp extract_session_id(message) when is_map(message) do
+    Map.get(message, "session_id") ||
+      Map.get(message, :session_id) ||
+      get_in(message, ["data", "session_id"]) ||
+      get_in(message, [:data, :session_id])
+  end
+
+  defp extract_session_id(_message), do: nil
+
+  defp extract_usage(message) when is_map(message) do
+    Map.get(message, "usage") ||
+      Map.get(message, :usage) ||
+      get_in(message, ["message", "usage"]) ||
+      get_in(message, [:message, :usage])
+  end
+
+  defp extract_usage(_message), do: nil
+end

--- a/elixir/lib/symphony_elixir/agent_backend/command_port.ex
+++ b/elixir/lib/symphony_elixir/agent_backend/command_port.ex
@@ -1,0 +1,180 @@
+defmodule SymphonyElixir.AgentBackend.CommandPort do
+  @moduledoc false
+
+  alias SymphonyElixir.{Config, Json, PathSafety, SSH}
+
+  @default_line_bytes 1_048_576
+
+  @type t :: %{
+          port: port(),
+          workspace: String.t(),
+          worker_host: String.t() | nil,
+          metadata: map()
+        }
+
+  @spec start(String.t(), String.t() | nil, String.t(), keyword()) :: {:ok, t()} | {:error, term()}
+  def start(workspace, worker_host, command, opts \\ [])
+      when is_binary(workspace) and is_binary(command) do
+    line_bytes = Keyword.get(opts, :line_bytes, @default_line_bytes)
+
+    with {:ok, expanded_workspace} <- validate_workspace_cwd(workspace, worker_host),
+         {:ok, port} <- start_port(expanded_workspace, worker_host, command, line_bytes) do
+      {:ok,
+       %{
+         port: port,
+         workspace: expanded_workspace,
+         worker_host: worker_host,
+         metadata: port_metadata(port, worker_host)
+       }}
+    end
+  end
+
+  @spec stop(t() | map()) :: :ok
+  def stop(%{port: port}) when is_port(port) do
+    Port.close(port)
+
+    receive do
+      {^port, {:exit_status, _status}} -> :ok
+    after
+      100 -> :ok
+    end
+  catch
+    :error, _reason -> :ok
+  end
+
+  def stop(_session), do: :ok
+
+  @spec send_json(port(), map()) :: :ok
+  def send_json(port, message) when is_port(port) and is_map(message) do
+    Port.command(port, Json.encode!(message) <> "\n")
+    :ok
+  end
+
+  @spec receive_json(port(), timeout(), String.t()) ::
+          {:ok, map(), String.t()} | {:malformed, String.t(), String.t()} | {:error, term()}
+  def receive_json(port, timeout_ms, pending_line \\ "")
+      when is_port(port) and is_integer(timeout_ms) and timeout_ms >= 0 and is_binary(pending_line) do
+    receive do
+      {^port, {:data, {:eol, chunk}}} ->
+        complete_line = pending_line <> to_string(chunk)
+
+        case Jason.decode(complete_line) do
+          {:ok, payload} when is_map(payload) ->
+            {:ok, payload, ""}
+
+          {:ok, payload} ->
+            {:malformed, inspect(payload), ""}
+
+          {:error, _reason} ->
+            {:malformed, complete_line, ""}
+        end
+
+      {^port, {:data, {:noeol, chunk}}} ->
+        receive_json(port, timeout_ms, pending_line <> to_string(chunk))
+
+      {^port, {:exit_status, status}} ->
+        {:error, {:port_exit, status}}
+    after
+      timeout_ms ->
+        {:error, :timeout}
+    end
+  end
+
+  @spec shell_escape(String.t()) :: String.t()
+  def shell_escape(value) when is_binary(value) do
+    "'" <> String.replace(value, "'", "'\"'\"'") <> "'"
+  end
+
+  defp validate_workspace_cwd(workspace, nil) when is_binary(workspace) do
+    expanded_workspace = Path.expand(workspace)
+    expanded_root = Path.expand(Config.settings!().workspace.root)
+    expanded_root_prefix = expanded_root <> "/"
+
+    with {:ok, canonical_workspace} <- PathSafety.canonicalize(expanded_workspace),
+         {:ok, canonical_root} <- PathSafety.canonicalize(expanded_root) do
+      canonical_root_prefix = canonical_root <> "/"
+
+      cond do
+        canonical_workspace == canonical_root ->
+          {:error, {:invalid_workspace_cwd, :workspace_root, canonical_workspace}}
+
+        String.starts_with?(canonical_workspace <> "/", canonical_root_prefix) ->
+          {:ok, canonical_workspace}
+
+        String.starts_with?(expanded_workspace <> "/", expanded_root_prefix) ->
+          {:error, {:invalid_workspace_cwd, :symlink_escape, expanded_workspace, canonical_root}}
+
+        true ->
+          {:error, {:invalid_workspace_cwd, :outside_workspace_root, canonical_workspace, canonical_root}}
+      end
+    else
+      {:error, {:path_canonicalize_failed, path, reason}} ->
+        {:error, {:invalid_workspace_cwd, :path_unreadable, path, reason}}
+    end
+  end
+
+  defp validate_workspace_cwd(workspace, worker_host)
+       when is_binary(workspace) and is_binary(worker_host) do
+    cond do
+      String.trim(workspace) == "" ->
+        {:error, {:invalid_workspace_cwd, :empty_remote_workspace, worker_host}}
+
+      String.contains?(workspace, ["\n", "\r", <<0>>]) ->
+        {:error, {:invalid_workspace_cwd, :invalid_remote_workspace, worker_host, workspace}}
+
+      true ->
+        {:ok, workspace}
+    end
+  end
+
+  defp start_port(workspace, nil, command, line_bytes) do
+    case System.find_executable("bash") do
+      nil ->
+        {:error, :bash_not_found}
+
+      executable ->
+        port =
+          Port.open(
+            {:spawn_executable, String.to_charlist(executable)},
+            [
+              :binary,
+              :exit_status,
+              :stderr_to_stdout,
+              args: [~c"-lc", String.to_charlist(command)],
+              cd: String.to_charlist(workspace),
+              line: line_bytes
+            ]
+          )
+
+        {:ok, port}
+    end
+  end
+
+  defp start_port(workspace, worker_host, command, line_bytes) when is_binary(worker_host) do
+    remote_command =
+      [
+        "cd #{shell_escape(workspace)}",
+        "exec #{command}"
+      ]
+      |> Enum.join(" && ")
+
+    SSH.start_port(worker_host, remote_command, line: line_bytes)
+  end
+
+  defp port_metadata(port, worker_host) when is_port(port) do
+    base_metadata =
+      case :erlang.port_info(port, :os_pid) do
+        {:os_pid, os_pid} ->
+          pid = to_string(os_pid)
+          %{worker_pid: pid, codex_app_server_pid: pid}
+
+        _ ->
+          %{}
+      end
+
+    case worker_host do
+      host when is_binary(host) -> Map.put(base_metadata, :worker_host, host)
+      _ -> base_metadata
+    end
+  end
+end

--- a/elixir/lib/symphony_elixir/agent_backend/command_port.ex
+++ b/elixir/lib/symphony_elixir/agent_backend/command_port.ex
@@ -58,7 +58,7 @@ defmodule SymphonyElixir.AgentBackend.CommandPort do
       {^port, {:data, {:eol, chunk}}} ->
         complete_line = pending_line <> to_string(chunk)
 
-        case Jason.decode(complete_line) do
+        case Json.decode(complete_line) do
           {:ok, payload} when is_map(payload) ->
             {:ok, payload, ""}
 

--- a/elixir/lib/symphony_elixir/agent_backend/resolver.ex
+++ b/elixir/lib/symphony_elixir/agent_backend/resolver.ex
@@ -3,12 +3,12 @@ defmodule SymphonyElixir.AgentBackend.Resolver do
   Resolves the backend module used by AgentRunner.
   """
 
-  alias SymphonyElixir.AgentBackend.CodexAppServer
+  alias SymphonyElixir.Config
 
   @spec resolve(keyword()) :: module()
   def resolve(opts \\ []) when is_list(opts) do
     Keyword.get(opts, :backend) ||
       Keyword.get(opts, :backend_module) ||
-      CodexAppServer
+      Config.agent_backend_module()
   end
 end

--- a/elixir/lib/symphony_elixir/config.ex
+++ b/elixir/lib/symphony_elixir/config.ex
@@ -28,6 +28,14 @@ defmodule SymphonyElixir.Config do
           turn_sandbox_policy: map()
         }
 
+  @type agent_backend_runtime_settings :: %{
+          id: String.t(),
+          command: String.t(),
+          turn_timeout_ms: pos_integer(),
+          read_timeout_ms: pos_integer(),
+          stall_timeout_ms: non_neg_integer()
+        }
+
   @spec settings() :: {:ok, Schema.t()} | {:error, term()}
   def settings do
     case Workflow.current() do
@@ -94,6 +102,45 @@ defmodule SymphonyElixir.Config do
   def validation_guidance(issue) do
     validation_settings()
     |> ValidationGuidance.resolve(issue)
+  end
+
+  @spec agent_backend_settings() :: agent_backend_runtime_settings()
+  def agent_backend_settings do
+    settings = settings!()
+    backend_id = selected_agent_backend_id(settings)
+
+    %{
+      id: backend_id,
+      command: selected_agent_backend_command(settings, backend_id),
+      turn_timeout_ms: settings.agent_backend.turn_timeout_ms || settings.codex.turn_timeout_ms,
+      read_timeout_ms: settings.agent_backend.read_timeout_ms || settings.codex.read_timeout_ms,
+      stall_timeout_ms: settings.agent_backend.stall_timeout_ms || settings.codex.stall_timeout_ms
+    }
+  end
+
+  @spec agent_backend_id() :: String.t()
+  def agent_backend_id do
+    settings!()
+    |> selected_agent_backend_id()
+  end
+
+  @spec agent_backend_module() :: module()
+  def agent_backend_module do
+    case agent_backend_id() do
+      "acp_stdio" ->
+        SymphonyElixir.AgentBackend.AcpStdio
+
+      "claude_cli_stream" ->
+        SymphonyElixir.AgentBackend.ClaudeCliStream
+
+      _ ->
+        SymphonyElixir.AgentBackend.CodexAppServer
+    end
+  end
+
+  @spec agent_stall_timeout_ms() :: non_neg_integer()
+  def agent_stall_timeout_ms do
+    agent_backend_settings().stall_timeout_ms
   end
 
   @spec server_port() :: non_neg_integer() | nil
@@ -163,5 +210,21 @@ defmodule SymphonyElixir.Config do
       other ->
         "Invalid WORKFLOW.md config: #{inspect(other)}"
     end
+  end
+
+  defp selected_agent_backend_id(settings) when is_map(settings) do
+    settings.agent_backend.id || "codex_app_server"
+  end
+
+  defp selected_agent_backend_command(settings, "acp_stdio") do
+    settings.agent_backend.command || "opencode acp"
+  end
+
+  defp selected_agent_backend_command(settings, "claude_cli_stream") do
+    settings.agent_backend.command || "claude"
+  end
+
+  defp selected_agent_backend_command(settings, _backend_id) do
+    settings.codex.command
   end
 end

--- a/elixir/lib/symphony_elixir/config/schema.ex
+++ b/elixir/lib/symphony_elixir/config/schema.ex
@@ -150,6 +150,35 @@ defmodule SymphonyElixir.Config.Schema do
     end
   end
 
+  defmodule AgentBackendConfig do
+    @moduledoc false
+    use Ecto.Schema
+    import Ecto.Changeset
+
+    alias SymphonyElixir.Config.Schema
+
+    @primary_key false
+    embedded_schema do
+      field(:id, :string, default: "codex_app_server")
+      field(:command, :string)
+      field(:turn_timeout_ms, :integer)
+      field(:read_timeout_ms, :integer)
+      field(:stall_timeout_ms, :integer)
+    end
+
+    @spec changeset(%__MODULE__{}, map()) :: Ecto.Changeset.t()
+    def changeset(schema, attrs) do
+      schema
+      |> cast(attrs, [:id, :command, :turn_timeout_ms, :read_timeout_ms, :stall_timeout_ms], empty_values: [])
+      |> update_change(:id, &Schema.normalize_backend_id/1)
+      |> validate_required([:id])
+      |> validate_inclusion(:id, Schema.supported_agent_backends(), message: "is unsupported")
+      |> validate_number(:turn_timeout_ms, greater_than: 0)
+      |> validate_number(:read_timeout_ms, greater_than: 0)
+      |> validate_number(:stall_timeout_ms, greater_than_or_equal_to: 0)
+    end
+  end
+
   defmodule Codex do
     @moduledoc false
     use Ecto.Schema
@@ -444,6 +473,7 @@ defmodule SymphonyElixir.Config.Schema do
     embeds_one(:workspace, Workspace, on_replace: :update, defaults_to_struct: true)
     embeds_one(:worker, Worker, on_replace: :update, defaults_to_struct: true)
     embeds_one(:agent, Agent, on_replace: :update, defaults_to_struct: true)
+    embeds_one(:agent_backend, AgentBackendConfig, on_replace: :update, defaults_to_struct: true)
     embeds_one(:codex, Codex, on_replace: :update, defaults_to_struct: true)
     embeds_one(:validation, Validation, on_replace: :update)
     embeds_one(:hooks, Hooks, on_replace: :update, defaults_to_struct: true)
@@ -505,8 +535,23 @@ defmodule SymphonyElixir.Config.Schema do
   def supported_validation_evidence_types, do: ["none", "logs", "screenshot", "video"]
 
   @doc false
+  @spec supported_agent_backends() :: [String.t()]
+  def supported_agent_backends, do: ["codex_app_server", "acp_stdio", "claude_cli_stream"]
+
+  @doc false
   @spec supported_validation_unavailable_behaviors() :: [String.t()]
   def supported_validation_unavailable_behaviors, do: ["manual_handoff", "blocked_with_reason"]
+
+  @doc false
+  @spec normalize_backend_id(term()) :: term()
+  def normalize_backend_id(value) when is_binary(value) do
+    value
+    |> String.trim()
+    |> String.downcase()
+    |> String.replace("-", "_")
+  end
+
+  def normalize_backend_id(value), do: value
 
   @doc false
   @spec normalize_validation_name(term()) :: term()
@@ -555,6 +600,7 @@ defmodule SymphonyElixir.Config.Schema do
     |> cast_embed(:workspace, with: &Workspace.changeset/2)
     |> cast_embed(:worker, with: &Worker.changeset/2)
     |> cast_embed(:agent, with: &Agent.changeset/2)
+    |> cast_embed(:agent_backend, with: &AgentBackendConfig.changeset/2)
     |> cast_embed(:codex, with: &Codex.changeset/2)
     |> cast_embed(:validation, with: &Validation.changeset/2)
     |> cast_embed(:hooks, with: &Hooks.changeset/2)
@@ -581,7 +627,14 @@ defmodule SymphonyElixir.Config.Schema do
           turn_sandbox_policy: normalize_optional_map(settings.codex.turn_sandbox_policy)
       }
 
-      {:ok, %{settings | tracker: tracker, workspace: workspace, codex: codex, validation: validation}}
+      {:ok,
+       %{
+         settings
+         | tracker: tracker,
+           workspace: workspace,
+           codex: codex,
+           validation: validation
+       }}
     end
   end
 

--- a/elixir/lib/symphony_elixir/json.ex
+++ b/elixir/lib/symphony_elixir/json.ex
@@ -3,6 +3,16 @@ defmodule SymphonyElixir.Json do
 
   @replacement <<0xEF, 0xBF, 0xBD>>
 
+  @spec decode(iodata(), keyword()) :: {:ok, term()} | {:error, Jason.DecodeError.t()}
+  def decode(value, opts \\ []) do
+    Jason.decode(value, opts)
+  end
+
+  @spec decode!(iodata(), keyword()) :: term()
+  def decode!(value, opts \\ []) do
+    Jason.decode!(value, opts)
+  end
+
   @spec encode!(term(), keyword()) :: String.t()
   def encode!(value, opts \\ []) do
     value

--- a/elixir/lib/symphony_elixir/orchestrator.ex
+++ b/elixir/lib/symphony_elixir/orchestrator.ex
@@ -440,7 +440,7 @@ defmodule SymphonyElixir.Orchestrator do
   end
 
   defp reconcile_stalled_running_issues(%State{} = state) do
-    timeout_ms = Config.settings!().codex.stall_timeout_ms
+    timeout_ms = Config.agent_stall_timeout_ms()
 
     cond do
       timeout_ms <= 0 ->

--- a/elixir/test/support/test_support.exs
+++ b/elixir/test/support/test_support.exs
@@ -107,6 +107,11 @@ defmodule SymphonyElixir.TestSupport do
           max_turns: 20,
           max_retry_backoff_ms: 300_000,
           max_concurrent_agents_by_state: %{},
+          agent_backend_id: nil,
+          agent_backend_command: nil,
+          agent_backend_turn_timeout_ms: nil,
+          agent_backend_read_timeout_ms: nil,
+          agent_backend_stall_timeout_ms: nil,
           codex_command: "codex app-server",
           codex_approval_policy: %{reject: %{sandbox_approval: true, rules: true, mcp_elicitations: true}},
           codex_thread_sandbox: "workspace-write",
@@ -144,6 +149,11 @@ defmodule SymphonyElixir.TestSupport do
     max_turns = Keyword.get(config, :max_turns)
     max_retry_backoff_ms = Keyword.get(config, :max_retry_backoff_ms)
     max_concurrent_agents_by_state = Keyword.get(config, :max_concurrent_agents_by_state)
+    agent_backend_id = Keyword.get(config, :agent_backend_id)
+    agent_backend_command = Keyword.get(config, :agent_backend_command)
+    agent_backend_turn_timeout_ms = Keyword.get(config, :agent_backend_turn_timeout_ms)
+    agent_backend_read_timeout_ms = Keyword.get(config, :agent_backend_read_timeout_ms)
+    agent_backend_stall_timeout_ms = Keyword.get(config, :agent_backend_stall_timeout_ms)
     codex_command = Keyword.get(config, :codex_command)
     codex_approval_policy = Keyword.get(config, :codex_approval_policy)
     codex_thread_sandbox = Keyword.get(config, :codex_thread_sandbox)
@@ -184,6 +194,13 @@ defmodule SymphonyElixir.TestSupport do
         "  max_turns: #{yaml_value(max_turns)}",
         "  max_retry_backoff_ms: #{yaml_value(max_retry_backoff_ms)}",
         "  max_concurrent_agents_by_state: #{yaml_value(max_concurrent_agents_by_state)}",
+        agent_backend_yaml(
+          agent_backend_id,
+          agent_backend_command,
+          agent_backend_turn_timeout_ms,
+          agent_backend_read_timeout_ms,
+          agent_backend_stall_timeout_ms
+        ),
         "codex:",
         "  command: #{yaml_value(codex_command)}",
         "  approval_policy: #{yaml_value(codex_approval_policy)}",
@@ -224,6 +241,21 @@ defmodule SymphonyElixir.TestSupport do
   end
 
   defp yaml_value(value), do: yaml_value(to_string(value))
+
+  defp agent_backend_yaml(nil, nil, nil, nil, nil), do: nil
+
+  defp agent_backend_yaml(id, command, turn_timeout_ms, read_timeout_ms, stall_timeout_ms) do
+    [
+      "agent_backend:",
+      id && "  id: #{yaml_value(id)}",
+      command && "  command: #{yaml_value(command)}",
+      turn_timeout_ms && "  turn_timeout_ms: #{yaml_value(turn_timeout_ms)}",
+      read_timeout_ms && "  read_timeout_ms: #{yaml_value(read_timeout_ms)}",
+      stall_timeout_ms && "  stall_timeout_ms: #{yaml_value(stall_timeout_ms)}"
+    ]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.join("\n")
+  end
 
   defp hooks_yaml(nil, nil, nil, nil, timeout_ms), do: "hooks:\n  timeout_ms: #{yaml_value(timeout_ms)}"
 

--- a/elixir/test/symphony_elixir/agent_backend/acp_stdio_test.exs
+++ b/elixir/test/symphony_elixir/agent_backend/acp_stdio_test.exs
@@ -1,0 +1,188 @@
+defmodule SymphonyElixir.AgentBackend.AcpStdioTest do
+  use SymphonyElixir.TestSupport
+
+  alias SymphonyElixir.AgentBackend.AcpStdio
+
+  test "acp stdio backend runs turns, auto-approves permission requests, and closes the session" do
+    test_root =
+      Path.join(
+        System.tmp_dir!(),
+        "symphony-elixir-agent-backend-acp-#{System.unique_integer([:positive])}"
+      )
+
+    try do
+      workspace_root = Path.join(test_root, "workspaces")
+      workspace_path = Path.join(workspace_root, "MT-ACP")
+      log_path = Path.join(test_root, "acp.log")
+      script_path = Path.join(test_root, "fake_acp.py")
+
+      File.mkdir_p!(workspace_path)
+      write_fake_acp_script!(script_path, log_path)
+
+      write_workflow_file!(Workflow.workflow_file_path(),
+        workspace_root: workspace_root,
+        agent_backend_id: "acp_stdio",
+        agent_backend_command: "python3 #{script_path} #{log_path}"
+      )
+
+      parent = self()
+
+      context = %{
+        on_event: fn event -> send(parent, {:acp_event, event}) end,
+        work_item: %{
+          id: "issue-acp",
+          identifier: "MT-ACP",
+          title: "ACP backend",
+          description: "Exercise ACP stdio"
+        },
+        worker_host: nil,
+        workspace_path: workspace_path
+      }
+
+      assert {:ok, session} = AcpStdio.start_session(context, [])
+      assert session.session_id == "sess-acp-test"
+
+      assert {:ok, result} =
+               AcpStdio.run_turn(session, %{prompt: "Inspect the repository", turn_number: 1}, [])
+
+      assert result.backend == :acp_stdio
+      assert result.session_id == "sess-acp-test-turn-1"
+      assert result.thread_id == "sess-acp-test"
+      assert result.turn_id == "1"
+
+      assert_receive {:acp_event, session_started}
+      assert session_started.event == :session_started
+      assert session_started.session_id == "sess-acp-test-turn-1"
+      assert session_started.thread_id == "sess-acp-test"
+      assert session_started.turn_id == "1"
+
+      assert_receive {:acp_event, permission_request}
+      assert permission_request.event == :notification
+      assert permission_request.payload["method"] == "session/request_permission"
+
+      assert_receive {:acp_event, update}
+      assert update.event == :notification
+      assert update.payload["method"] == "session/update"
+
+      assert_receive {:acp_event, completed}
+      assert completed.event == :turn_completed
+      assert completed.session_id == "sess-acp-test-turn-1"
+
+      assert :ok = AcpStdio.stop_session(session)
+
+      log = File.read!(log_path)
+      assert log =~ "permission=allow-once"
+      assert log =~ "close=sess-acp-test"
+    after
+      File.rm_rf(test_root)
+    end
+  end
+
+  defp write_fake_acp_script!(path, _log_path) do
+    script =
+      [
+        "import json",
+        "import sys",
+        "",
+        "log_path = sys.argv[1]",
+        "session_id = \"sess-acp-test\"",
+        "",
+        "def log(message):",
+        "    with open(log_path, \"a\", encoding=\"utf-8\") as handle:",
+        "        handle.write(message + \"\\\\n\")",
+        "",
+        "for line in sys.stdin:",
+        "    line = line.strip()",
+        "    if not line:",
+        "        continue",
+        "",
+        "    payload = json.loads(line)",
+        "    method = payload.get(\"method\")",
+        "",
+        "    if method == \"initialize\":",
+        "        print(json.dumps({",
+        "            \"jsonrpc\": \"2.0\",",
+        "            \"id\": payload[\"id\"],",
+        "            \"result\": {",
+        "                \"protocolVersion\": 1,",
+        "                \"agentCapabilities\": {",
+        "                    \"sessionCapabilities\": {",
+        "                        \"close\": {}",
+        "                    }",
+        "                }",
+        "            }",
+        "        }), flush=True)",
+        "    elif method == \"session/new\":",
+        "        print(json.dumps({",
+        "            \"jsonrpc\": \"2.0\",",
+        "            \"id\": payload[\"id\"],",
+        "            \"result\": {",
+        "                \"sessionId\": session_id",
+        "            }",
+        "        }), flush=True)",
+        "    elif method == \"session/prompt\":",
+        "        print(json.dumps({",
+        "            \"jsonrpc\": \"2.0\",",
+        "            \"id\": 90,",
+        "            \"method\": \"session/request_permission\",",
+        "            \"params\": {",
+        "                \"sessionId\": session_id,",
+        "                \"toolCall\": {",
+        "                    \"toolCallId\": \"call-1\"",
+        "                },",
+        "                \"options\": [",
+        "                    {",
+        "                        \"optionId\": \"allow-once\",",
+        "                        \"name\": \"Allow once\",",
+        "                        \"kind\": \"allow_once\"",
+        "                    },",
+        "                    {",
+        "                        \"optionId\": \"reject-once\",",
+        "                        \"name\": \"Reject\",",
+        "                        \"kind\": \"reject_once\"",
+        "                    }",
+        "                ]",
+        "            }",
+        "        }), flush=True)",
+        "",
+        "        permission_response = json.loads(sys.stdin.readline())",
+        "        option_id = permission_response[\"result\"][\"outcome\"][\"optionId\"]",
+        "        log(f\"permission={option_id}\")",
+        "",
+        "        print(json.dumps({",
+        "            \"jsonrpc\": \"2.0\",",
+        "            \"method\": \"session/update\",",
+        "            \"params\": {",
+        "                \"sessionId\": session_id,",
+        "                \"update\": {",
+        "                    \"sessionUpdate\": \"agent_message_chunk\",",
+        "                    \"content\": {",
+        "                        \"type\": \"text\",",
+        "                        \"text\": \"working\"",
+        "                    }",
+        "                }",
+        "            }",
+        "        }), flush=True)",
+        "",
+        "        print(json.dumps({",
+        "            \"jsonrpc\": \"2.0\",",
+        "            \"id\": payload[\"id\"],",
+        "            \"result\": {",
+        "                \"stopReason\": \"end_turn\"",
+        "            }",
+        "        }), flush=True)",
+        "    elif method == \"session/close\":",
+        "        log(f\"close={payload['params']['sessionId']}\")",
+        "        print(json.dumps({",
+        "            \"jsonrpc\": \"2.0\",",
+        "            \"id\": payload[\"id\"],",
+        "            \"result\": {}",
+        "        }), flush=True)",
+        "        break",
+        ""
+      ]
+      |> Enum.join("\n")
+
+    File.write!(path, script)
+  end
+end

--- a/elixir/test/symphony_elixir/agent_backend/claude_cli_stream_test.exs
+++ b/elixir/test/symphony_elixir/agent_backend/claude_cli_stream_test.exs
@@ -1,0 +1,160 @@
+defmodule SymphonyElixir.AgentBackend.ClaudeCliStreamTest do
+  use SymphonyElixir.TestSupport
+
+  alias SymphonyElixir.AgentBackend.ClaudeCliStream
+
+  test "claude cli stream backend resumes the same Claude session across turns" do
+    test_root =
+      Path.join(
+        System.tmp_dir!(),
+        "symphony-elixir-agent-backend-claude-#{System.unique_integer([:positive])}"
+      )
+
+    try do
+      workspace_root = Path.join(test_root, "workspaces")
+      workspace_path = Path.join(workspace_root, "MT-CLAUDE")
+      log_path = Path.join(test_root, "claude.log")
+      script_path = Path.join(test_root, "fake_claude.py")
+
+      File.mkdir_p!(workspace_path)
+      write_fake_claude_script!(script_path, log_path)
+
+      write_workflow_file!(Workflow.workflow_file_path(),
+        workspace_root: workspace_root,
+        agent_backend_id: "claude_cli_stream",
+        agent_backend_command: "python3 #{script_path} #{log_path}"
+      )
+
+      parent = self()
+
+      context = %{
+        on_event: fn event -> send(parent, {:claude_event, event}) end,
+        work_item: %{
+          id: "issue-claude",
+          identifier: "MT-CLAUDE",
+          title: "Claude backend",
+          description: "Exercise Claude CLI stream"
+        },
+        worker_host: nil,
+        workspace_path: workspace_path
+      }
+
+      assert {:ok, session} = ClaudeCliStream.start_session(context, [])
+      assert is_pid(session)
+
+      assert {:ok, first_result} =
+               ClaudeCliStream.run_turn(session, %{prompt: "First prompt", turn_number: 1}, [])
+
+      assert first_result.backend == :claude_cli_stream
+      assert first_result.thread_id == "claude-session-1"
+      assert first_result.session_id == "claude-session-1-turn-1"
+      assert first_result.turn_id == "1"
+      assert first_result.result == "handled: First prompt"
+
+      assert_receive {:claude_event, first_started}
+      assert first_started.event == :session_started
+      assert first_started.thread_id == "claude-session-1"
+      assert first_started.session_id == "claude-session-1-turn-1"
+
+      assert_receive {:claude_event, first_notification}
+      assert first_notification.event == :notification
+      assert first_notification.payload["type"] == "system"
+
+      assert_receive {:claude_event, first_stream}
+      assert first_stream.event == :notification
+      assert first_stream.payload["type"] == "stream_event"
+
+      assert_receive {:claude_event, first_completed}
+      assert first_completed.event == :turn_completed
+      assert first_completed.usage == %{"input_tokens" => 2, "output_tokens" => 3, "total_tokens" => 5}
+
+      assert {:ok, second_result} =
+               ClaudeCliStream.run_turn(session, %{prompt: "Second prompt", turn_number: 2}, [])
+
+      assert second_result.thread_id == "claude-session-1"
+      assert second_result.session_id == "claude-session-1-turn-2"
+      assert second_result.turn_id == "2"
+      assert second_result.result == "handled: Second prompt"
+
+      assert_receive {:claude_event, second_started}
+      assert second_started.event == :session_started
+      assert second_started.session_id == "claude-session-1-turn-2"
+
+      assert_receive {:claude_event, second_notification}
+      assert second_notification.event == :notification
+      assert second_notification.payload["type"] == "system"
+
+      assert_receive {:claude_event, second_stream}
+      assert second_stream.event == :notification
+      assert second_stream.payload["type"] == "stream_event"
+
+      assert_receive {:claude_event, second_completed}
+      assert second_completed.event == :turn_completed
+
+      assert :ok = ClaudeCliStream.stop_session(session)
+
+      log = File.read!(log_path)
+      assert log =~ "resume=None|prompt=First prompt"
+      assert log =~ "resume=claude-session-1|prompt=Second prompt"
+    after
+      File.rm_rf(test_root)
+    end
+  end
+
+  defp write_fake_claude_script!(path, _log_path) do
+    script =
+      [
+        "import json",
+        "import sys",
+        "",
+        "args = sys.argv[2:]",
+        "log_path = sys.argv[1]",
+        "",
+        "resume_value = None",
+        "prompt = args[-1]",
+        "",
+        "for index, value in enumerate(args):",
+        "    if value == \"--resume\":",
+        "        resume_value = args[index + 1]",
+        "",
+        "session_id = resume_value or \"claude-session-1\"",
+        "",
+        "with open(log_path, \"a\", encoding=\"utf-8\") as handle:",
+        "    handle.write(f\"resume={resume_value}|prompt={prompt}\\\\n\")",
+        "",
+        "print(json.dumps({",
+        "    \"type\": \"system\",",
+        "    \"subtype\": \"init\",",
+        "    \"session_id\": session_id",
+        "}), flush=True)",
+        "",
+        "print(json.dumps({",
+        "    \"type\": \"stream_event\",",
+        "    \"session_id\": session_id,",
+        "    \"event\": {",
+        "        \"type\": \"content_block_delta\",",
+        "        \"delta\": {",
+        "            \"type\": \"text_delta\",",
+        "            \"text\": \"working\"",
+        "        }",
+        "    }",
+        "}), flush=True)",
+        "",
+        "print(json.dumps({",
+        "    \"type\": \"result\",",
+        "    \"subtype\": \"success\",",
+        "    \"session_id\": session_id,",
+        "    \"usage\": {",
+        "        \"input_tokens\": 2,",
+        "        \"output_tokens\": 3,",
+        "        \"total_tokens\": 5",
+        "    },",
+        "    \"result\": f\"handled: {prompt}\"",
+        "}), flush=True)",
+        ""
+      ]
+      |> Enum.join("\n")
+
+    File.write!(path, script)
+  end
+end

--- a/elixir/test/symphony_elixir/agent_backend_test.exs
+++ b/elixir/test/symphony_elixir/agent_backend_test.exs
@@ -2,6 +2,8 @@ defmodule SymphonyElixir.AgentBackendTest do
   use SymphonyElixir.TestSupport
 
   alias SymphonyElixir.AgentBackend
+  alias SymphonyElixir.AgentBackend.AcpStdio
+  alias SymphonyElixir.AgentBackend.ClaudeCliStream
   alias SymphonyElixir.AgentBackend.CodexAppServer
   alias SymphonyElixir.AgentBackend.Resolver
 
@@ -79,5 +81,11 @@ defmodule SymphonyElixir.AgentBackendTest do
 
     assert Resolver.resolve(backend: :fake_backend, backend_module: Resolver) ==
              :fake_backend
+
+    write_workflow_file!(Workflow.workflow_file_path(), agent_backend_id: "acp_stdio")
+    assert Resolver.resolve() == AcpStdio
+
+    write_workflow_file!(Workflow.workflow_file_path(), agent_backend_id: "claude_cli_stream")
+    assert Resolver.resolve() == ClaudeCliStream
   end
 end

--- a/elixir/test/symphony_elixir/agent_runner_test.exs
+++ b/elixir/test/symphony_elixir/agent_runner_test.exs
@@ -258,4 +258,160 @@ defmodule SymphonyElixir.AgentRunnerTest do
       File.rm_rf(test_root)
     end
   end
+
+  test "agent runner uses the configured claude cli backend without an opts override" do
+    test_root =
+      Path.join(
+        System.tmp_dir!(),
+        "symphony-elixir-agent-runner-configured-backend-#{System.unique_integer([:positive])}"
+      )
+
+    try do
+      workspace_root = Path.join(test_root, "workspaces")
+      log_path = Path.join(test_root, "claude-runner.log")
+      script_path = Path.join(test_root, "fake_claude_runner.py")
+      issue_id = "issue-configured-backend"
+      issue_identifier = "MT-427"
+
+      File.mkdir_p!(test_root)
+      write_fake_claude_stream_script!(script_path, log_path)
+
+      issue = %Issue{
+        id: issue_id,
+        identifier: issue_identifier,
+        title: "Configured backend",
+        description: "Exercise workflow-based backend selection",
+        state: "In Progress",
+        url: "https://example.org/issues/MT-427",
+        labels: []
+      }
+
+      write_workflow_file!(Workflow.workflow_file_path(),
+        workspace_root: workspace_root,
+        max_turns: 3,
+        agent_backend_id: "claude_cli_stream",
+        agent_backend_command: "python3 #{script_path} #{log_path}"
+      )
+
+      Process.delete(:configured_backend_state_fetches)
+
+      state_fetcher = fn [_issue_id] ->
+        next_count = Process.get(:configured_backend_state_fetches, 0) + 1
+        Process.put(:configured_backend_state_fetches, next_count)
+
+        state =
+          case next_count do
+            1 -> "In Progress"
+            _ -> "Done"
+          end
+
+        {:ok, [%Issue{issue | state: state}]}
+      end
+
+      assert :ok =
+               AgentRunner.run(
+                 issue,
+                 self(),
+                 issue_state_fetcher: state_fetcher,
+                 max_turns: 3
+               )
+
+      assert_receive {:agent_worker_update, ^issue_id, started_1}
+      assert started_1.event == :session_started
+      assert started_1.thread_id == "claude-session-1"
+      assert started_1.session_id == "claude-session-1-turn-1"
+
+      assert_receive {:agent_worker_update, ^issue_id, notification_1}
+      assert notification_1.event == :notification
+      assert notification_1.payload["type"] == "system"
+
+      assert_receive {:agent_worker_update, ^issue_id, stream_1}
+      assert stream_1.event == :notification
+      assert stream_1.payload["type"] == "stream_event"
+
+      assert_receive {:agent_worker_update, ^issue_id, completed_1}
+      assert completed_1.event == :turn_completed
+
+      assert_receive {:agent_worker_update, ^issue_id, started_2}
+      assert started_2.event == :session_started
+      assert started_2.thread_id == "claude-session-1"
+      assert started_2.session_id == "claude-session-1-turn-2"
+
+      assert_receive {:agent_worker_update, ^issue_id, notification_2}
+      assert notification_2.event == :notification
+      assert notification_2.payload["type"] == "system"
+
+      assert_receive {:agent_worker_update, ^issue_id, stream_2}
+      assert stream_2.event == :notification
+      assert stream_2.payload["type"] == "stream_event"
+
+      assert_receive {:agent_worker_update, ^issue_id, completed_2}
+      assert completed_2.event == :turn_completed
+      assert Process.get(:configured_backend_state_fetches) == 2
+
+      log = File.read!(log_path)
+      assert log =~ "resume=None|prompt="
+      assert log =~ "resume=claude-session-1|prompt=Continuation guidance:"
+    after
+      Process.delete(:configured_backend_state_fetches)
+      File.rm_rf(test_root)
+    end
+  end
+
+  defp write_fake_claude_stream_script!(path, _log_path) do
+    script =
+      [
+        "import json",
+        "import sys",
+        "",
+        "args = sys.argv[2:]",
+        "log_path = sys.argv[1]",
+        "",
+        "resume_value = None",
+        "prompt = args[-1]",
+        "",
+        "for index, value in enumerate(args):",
+        "    if value == \"--resume\":",
+        "        resume_value = args[index + 1]",
+        "",
+        "session_id = resume_value or \"claude-session-1\"",
+        "",
+        "with open(log_path, \"a\", encoding=\"utf-8\") as handle:",
+        "    handle.write(f\"resume={resume_value}|prompt={prompt}\\\\n\")",
+        "",
+        "print(json.dumps({",
+        "    \"type\": \"system\",",
+        "    \"subtype\": \"init\",",
+        "    \"session_id\": session_id",
+        "}), flush=True)",
+        "",
+        "print(json.dumps({",
+        "    \"type\": \"stream_event\",",
+        "    \"session_id\": session_id,",
+        "    \"event\": {",
+        "        \"type\": \"content_block_delta\",",
+        "        \"delta\": {",
+        "            \"type\": \"text_delta\",",
+        "            \"text\": \"runner\"",
+        "        }",
+        "    }",
+        "}), flush=True)",
+        "",
+        "print(json.dumps({",
+        "    \"type\": \"result\",",
+        "    \"subtype\": \"success\",",
+        "    \"session_id\": session_id,",
+        "    \"usage\": {",
+        "        \"input_tokens\": 2,",
+        "        \"output_tokens\": 3,",
+        "        \"total_tokens\": 5",
+        "    },",
+        "    \"result\": prompt",
+        "}), flush=True)",
+        ""
+      ]
+      |> Enum.join("\n")
+
+    File.write!(path, script)
+  end
 end

--- a/elixir/test/symphony_elixir/json_test.exs
+++ b/elixir/test/symphony_elixir/json_test.exs
@@ -8,4 +8,9 @@ defmodule SymphonyElixir.JsonTest do
 
     assert Json.sanitize(date) == date
   end
+
+  test "decode delegates to Jason" do
+    assert Json.decode("{\"ok\":true}") == {:ok, %{"ok" => true}}
+    assert Json.decode!("{\"ok\":true}") == %{"ok" => true}
+  end
 end

--- a/elixir/test/symphony_elixir/workspace_and_config_test.exs
+++ b/elixir/test/symphony_elixir/workspace_and_config_test.exs
@@ -744,6 +744,7 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
     assert config.workspace.root == Path.join(System.tmp_dir!(), "symphony_workspaces")
     assert config.worker.max_concurrent_agents_per_host == nil
     assert config.agent.max_concurrent_agents == 10
+    assert config.agent_backend.id == "codex_app_server"
     assert config.codex.command == "codex app-server"
 
     assert config.codex.approval_policy == %{
@@ -772,8 +773,42 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
     assert config.codex.read_timeout_ms == 5_000
     assert config.codex.stall_timeout_ms == 300_000
 
+    assert Config.agent_backend_settings() == %{
+             id: "codex_app_server",
+             command: "codex app-server",
+             turn_timeout_ms: 3_600_000,
+             read_timeout_ms: 5_000,
+             stall_timeout_ms: 300_000
+           }
+
     write_workflow_file!(Workflow.workflow_file_path(), codex_command: "codex app-server --model gpt-5.3-codex")
     assert Config.settings!().codex.command == "codex app-server --model gpt-5.3-codex"
+
+    write_workflow_file!(Workflow.workflow_file_path(), agent_backend_id: "acp_stdio")
+
+    assert Config.agent_backend_settings() == %{
+             id: "acp_stdio",
+             command: "opencode acp",
+             turn_timeout_ms: 3_600_000,
+             read_timeout_ms: 5_000,
+             stall_timeout_ms: 300_000
+           }
+
+    write_workflow_file!(Workflow.workflow_file_path(),
+      agent_backend_id: "claude_cli_stream",
+      agent_backend_command: "claude --bare",
+      agent_backend_turn_timeout_ms: 42_000,
+      agent_backend_read_timeout_ms: 7_000,
+      agent_backend_stall_timeout_ms: 99_000
+    )
+
+    assert Config.agent_backend_settings() == %{
+             id: "claude_cli_stream",
+             command: "claude --bare",
+             turn_timeout_ms: 42_000,
+             read_timeout_ms: 7_000,
+             stall_timeout_ms: 99_000
+           }
 
     explicit_root =
       Path.join(


### PR DESCRIPTION
#### Context

Implement the "true multi-backend support" slice from `DISCUSSION_REPORT.md` by letting
workflows select real non-Codex backends while preserving the existing Codex
compatibility path.

#### TL;DR

*Workflows can now choose Codex, OpenCode ACP, or Claude CLI backends through `agent_backend` config.*

#### Summary

- Add an `agent_backend` workflow block and resolve the runtime backend from workflow settings.
- Implement `acp_stdio` for `opencode acp` and `claude_cli_stream` with Claude session resume support.
- Share command-port and JSON helpers for backend process IO.
- Add regression coverage for config parsing, backend lifecycles, and AgentRunner backend selection.

#### Alternatives

- Keep test-only backend overrides and a Codex-only workflow block. Rejected because operators still
  could not select real non-Codex backends.
- Wait for a larger executor refactor before supporting OpenCode or Claude. Rejected because the
  backend contract already exists and this ticket is specifically about landing production backend
  selection.
- Force every backend through ACP first. Rejected because Claude CLI stream already has a stable
  session-resume path, while an ACP-compatible Claude server is not guaranteed.

#### Test Plan

- [ ] `make -C elixir all` (currently fails due pre-existing `mix format --check-formatted` drift in `elixir/lib/symphony_elixir/codex/app_server.ex`, unchanged in this PR)
- [x] `cd elixir && mise exec -- mix test`
- [x] `cd elixir && mise exec -- mix format --check-formatted lib/symphony_elixir/json.ex lib/symphony_elixir/agent_backend/command_port.ex test/symphony_elixir/json_test.exs`
