### PR TITLE
fix: make AgentRunner backend validation load-aware

### DIFF
--- a/elixir/lib/symphony_elixir/agent_runner.ex
+++ b/elixir/lib/symphony_elixir/agent_runner.ex
@@ -7,6 +7,12 @@ defmodule SymphonyElixir.AgentRunner do
   alias SymphonyElixir.AgentBackend.Resolver
   alias SymphonyElixir.{Config, Linear.Issue, PromptBuilder, Tracker, Workspace}
 
+  @required_backend_callbacks [
+    start_session: 2,
+    run_turn: 3,
+    stop_session: 1
+  ]
+
   @type worker_host :: String.t() | nil
 
   @spec run(map(), pid() | nil, keyword()) :: :ok | no_return()
@@ -105,19 +111,42 @@ defmodule SymphonyElixir.AgentRunner do
   end
 
   @dialyzer {:nowarn_function, ensure_backend_module!: 1}
-  defp ensure_backend_module!(backend_module) do
-    if is_atom(backend_module) and backend_module_valid?(backend_module) do
-      backend_module
-    else
-      raise ArgumentError,
-            "Resolved backend #{inspect(backend_module)} does not implement AgentBackend callbacks"
+  defp ensure_backend_module!(backend_module) when is_atom(backend_module) do
+    case Code.ensure_loaded(backend_module) do
+      {:module, ^backend_module} ->
+        ensure_backend_callbacks!(backend_module)
+
+      {:error, reason} ->
+        raise ArgumentError,
+              "Resolved backend #{inspect(backend_module)} could not be loaded: #{inspect(reason)}"
     end
   end
 
-  defp backend_module_valid?(backend_module) do
-    function_exported?(backend_module, :start_session, 2) and
-      function_exported?(backend_module, :run_turn, 3) and
-      function_exported?(backend_module, :stop_session, 1)
+  defp ensure_backend_module!(backend_module) do
+    raise ArgumentError, "Resolved backend #{inspect(backend_module)} is not a module atom"
+  end
+
+  defp ensure_backend_callbacks!(backend_module) do
+    case missing_backend_callbacks(backend_module) do
+      [] ->
+        backend_module
+
+      missing_callbacks ->
+        formatted_callbacks = format_callback_signatures(missing_callbacks)
+
+        raise ArgumentError,
+              "Resolved backend #{inspect(backend_module)} does not implement AgentBackend callbacks: #{formatted_callbacks}"
+    end
+  end
+
+  defp missing_backend_callbacks(backend_module) do
+    Enum.reject(@required_backend_callbacks, fn {name, arity} ->
+      function_exported?(backend_module, name, arity)
+    end)
+  end
+
+  defp format_callback_signatures(callbacks) do
+    Enum.map_join(callbacks, ", ", fn {name, arity} -> "#{name}/#{arity}" end)
   end
 
   defp do_run_backend_turns(context, turn_number) do

--- a/elixir/test/symphony_elixir/agent_runner_test.exs
+++ b/elixir/test/symphony_elixir/agent_runner_test.exs
@@ -62,6 +62,21 @@ defmodule SymphonyElixir.AgentRunnerTest do
     def stop_session(_session), do: :ok
   end
 
+  defmodule MissingStopSessionBackend do
+    def start_session(_context, _opts), do: {:ok, :missing_stop_session}
+
+    def run_turn(_session, turn, _opts) do
+      {:ok,
+       %{
+         backend: :missing_stop_session,
+         result: :ok,
+         session_id: "missing-stop-session-#{turn.turn_number}",
+         thread_id: "missing-stop-thread",
+         turn_id: Integer.to_string(turn.turn_number)
+       }}
+    end
+  end
+
   test "agent runner resolves backend override, forwards updates, continues, and stops session" do
     test_root =
       Path.join(
@@ -225,23 +240,24 @@ defmodule SymphonyElixir.AgentRunnerTest do
     end
   end
 
-  test "agent runner rejects backends that do not implement the AgentBackend callbacks" do
+  test "agent runner raises load failure when backend module cannot be loaded" do
     test_root =
       Path.join(
         System.tmp_dir!(),
-        "symphony-elixir-agent-runner-invalid-backend-#{System.unique_integer([:positive])}"
+        "symphony-elixir-agent-runner-missing-backend-#{System.unique_integer([:positive])}"
       )
 
     try do
       workspace_root = Path.join(test_root, "workspaces")
-      issue_id = "issue-invalid-backend"
+      issue_id = "issue-missing-backend"
       issue_identifier = "MT-426"
+      missing_module = Module.concat([__MODULE__, "MissingBackend#{System.unique_integer([:positive])}"])
 
       issue = %Issue{
         id: issue_id,
         identifier: issue_identifier,
-        title: "Invalid backend",
-        description: "Exercise backend validation",
+        title: "Missing backend",
+        description: "Exercise backend module load failure",
         state: "In Progress",
         url: "https://example.org/issues/MT-426",
         labels: []
@@ -251,8 +267,42 @@ defmodule SymphonyElixir.AgentRunnerTest do
         workspace_root: workspace_root
       )
 
-      assert_raise ArgumentError, ~r/does not implement AgentBackend callbacks/, fn ->
-        AgentRunner.run(issue, self(), backend: :fake_backend)
+      assert_raise ArgumentError, ~r/could not be loaded/, fn ->
+        AgentRunner.run(issue, self(), backend: missing_module)
+      end
+    after
+      File.rm_rf(test_root)
+    end
+  end
+
+  test "agent runner raises callback contract failure for loaded invalid backend modules" do
+    test_root =
+      Path.join(
+        System.tmp_dir!(),
+        "symphony-elixir-agent-runner-callback-mismatch-#{System.unique_integer([:positive])}"
+      )
+
+    try do
+      workspace_root = Path.join(test_root, "workspaces")
+      issue_id = "issue-callback-mismatch"
+      issue_identifier = "MT-428"
+
+      issue = %Issue{
+        id: issue_id,
+        identifier: issue_identifier,
+        title: "Callback mismatch backend",
+        description: "Exercise callback contract validation",
+        state: "In Progress",
+        url: "https://example.org/issues/MT-428",
+        labels: []
+      }
+
+      write_workflow_file!(Workflow.workflow_file_path(),
+        workspace_root: workspace_root
+      )
+
+      assert_raise ArgumentError, ~r/does not implement AgentBackend callbacks: stop_session\/1/, fn ->
+        AgentRunner.run(issue, self(), backend: MissingStopSessionBackend)
       end
     after
       File.rm_rf(test_root)
@@ -275,6 +325,10 @@ defmodule SymphonyElixir.AgentRunnerTest do
 
       File.mkdir_p!(test_root)
       write_fake_claude_stream_script!(script_path, log_path)
+      backend_module = SymphonyElixir.AgentBackend.ClaudeCliStream
+      unload_module(backend_module)
+
+      assert :code.is_loaded(backend_module) == false
 
       issue = %Issue{
         id: issue_id,
@@ -315,6 +369,8 @@ defmodule SymphonyElixir.AgentRunnerTest do
                  issue_state_fetcher: state_fetcher,
                  max_turns: 3
                )
+
+      assert match?({:file, _}, :code.is_loaded(backend_module))
 
       assert_receive {:agent_worker_update, ^issue_id, started_1}
       assert started_1.event == :session_started
@@ -413,5 +469,11 @@ defmodule SymphonyElixir.AgentRunnerTest do
       |> Enum.join("\n")
 
     File.write!(path, script)
+  end
+
+  defp unload_module(module) when is_atom(module) do
+    :code.purge(module)
+    :code.delete(module)
+    :ok
   end
 end

--- a/openspec/changes/fix-backend-module-validation-loading/tasks.md
+++ b/openspec/changes/fix-backend-module-validation-loading/tasks.md
@@ -1,17 +1,17 @@
 ## 1. Backend Validation Logic
 
-- [ ] 1.1 Update `AgentRunner` backend validation to ensure the resolved backend module is loaded before callback export checks.
-- [ ] 1.2 Implement differentiated error handling/messages for module load failure versus callback-contract mismatch.
-- [ ] 1.3 Keep existing callback contract enforcement for `start_session/2`, `run_turn/3`, and `stop_session/1`.
+- [x] 1.1 Update `AgentRunner` backend validation to ensure the resolved backend module is loaded before callback export checks.
+- [x] 1.2 Implement differentiated error handling/messages for module load failure versus callback-contract mismatch.
+- [x] 1.3 Keep existing callback contract enforcement for `start_session/2`, `run_turn/3`, and `stop_session/1`.
 
 ## 2. Regression Test Coverage
 
-- [ ] 2.1 Add or update `agent_runner` tests to cover a valid backend module that is not preloaded at validation time.
-- [ ] 2.2 Add or update tests for backend module load failure behavior and assert it is distinguishable from callback mismatch.
-- [ ] 2.3 Add or update tests for loaded modules missing required callbacks and assert contract failure semantics.
+- [x] 2.1 Add or update `agent_runner` tests to cover a valid backend module that is not preloaded at validation time.
+- [x] 2.2 Add or update tests for backend module load failure behavior and assert it is distinguishable from callback mismatch.
+- [x] 2.3 Add or update tests for loaded modules missing required callbacks and assert contract failure semantics.
 
 ## 3. Verification
 
-- [ ] 3.1 Run targeted Elixir tests for backend validation and `AgentRunner` paths.
-- [ ] 3.2 Confirm no behavior regression for existing valid backend resolution paths.
-- [ ] 3.3 Document verification outcomes in the implementation workpad or PR notes.
+- [x] 3.1 Run targeted Elixir tests for backend validation and `AgentRunner` paths.
+- [x] 3.2 Confirm no behavior regression for existing valid backend resolution paths.
+- [x] 3.3 Document verification outcomes in the implementation workpad or PR notes.


### PR DESCRIPTION
#### Context

Backend validation in `AgentRunner` checked callbacks before loading modules,
causing false `ArgumentError` failures for valid unloaded backends.

#### TL;DR

*Load the backend module before callback checks and split load vs callback errors.*

#### Summary

- Load resolved backend modules with `Code.ensure_loaded/1` before validation
- Keep strict callback contract checks for `start_session/2`, `run_turn/3`, `stop_session/1`
- Emit distinct errors for module load failure vs callback mismatch
- Add regression tests for unloaded-valid backend and invalid backend paths
- Mark OpenSpec change tasks complete for this ticket

#### Alternatives

- Rely on runtime backend calls to fail naturally; rejected because errors become late and less actionable
- Keep one generic validation error; rejected because it obscures root cause

#### Test Plan

- [ ] `make -C elixir all` (fails due existing fmt-check in `elixir/lib/symphony_elixir/codex/app_server.ex`)
- [x] `cd elixir && mise exec -- mix test`
- [x] `cd elixir && mise exec -- mix test test/symphony_elixir/agent_runner_test.exs`
- [x] `cd elixir && mise exec -- mix test test/symphony_elixir/agent_runner_test.exs:312`
- [x] `cd elixir && mise exec -- mix run -e "... Code.ensure_loaded + function_exported reproduction ..."`
